### PR TITLE
Fix #ratio_table anchor renaming

### DIFF
--- a/flamegraph.html
+++ b/flamegraph.html
@@ -93,7 +93,7 @@
         .text(d => d)
         .style("font-size", "12px");
         
-      $('#todo_table').DataTable({
+      $('#ratio_table').DataTable({
           scrollX: true,
           scrollY: '80vh',
           scrollCollapse: true,


### PR DESCRIPTION
The anchor #todo_table was renamed to #ratio_table
during squash, but one occurence flew under the radar
fixes up https://github.com/BenWiederhake/serenity-fixmes/commit/e79ee2125a1b088afe17cd0c590dc01828dd7a98